### PR TITLE
Prevent Duplicate Assistant Messages When Accepting Spoilers in `Ask AI` modal.

### DIFF
--- a/components/global/ChatbotModal.vue
+++ b/components/global/ChatbotModal.vue
@@ -308,11 +308,17 @@ export default {
 
     showSpoilerContent() {
       this.chatBotResponse = this.pendingSpoilerResponse;
+
+      const messageExists = this.chatMessages.some(
+        msg => msg.role === 'assistant' && msg.content === this.pendingSpoilerResponse
+      );
       
-      this.chatMessages.push({
-        role: 'assistant',
-        content: this.pendingSpoilerResponse
-      });
+      if (!messageExists) {
+        this.chatMessages.push({
+          role: 'assistant',
+          content: this.pendingSpoilerResponse
+        });
+      }
       
       if (this.pendingSpoilerMediaReferences && this.pendingSpoilerMediaReferences.length > 0) {
         this.fetchMediaDetailsFromBackendReferences(this.pendingSpoilerMediaReferences);


### PR DESCRIPTION
This PR addresses a rendering inconsistency in the `ChatbotModal.vue` component where assistant responses would appear duplicated in the conversation history sometimes when users accepted spoiler content. Previously, when a user clicked "I can handle the truth" on a spoiler warning, the assistant's response would be added to the chat messages array without verifying if it already existed there.

The expected impact is a cleaner, more consistent conversation experience in the "Ask AI" feature when interacting with spoiler content.

## Changes Made

1. **Fixed Duplicate Messages in Spoiler Content:**
   - Added logic to verify if the assistant response already exists in the conversation history
   - Implemented a conditional check before adding messages to the chat array
   - Used array's `some()` method to efficiently detect duplicates

2. **Maintained Existing Functionality:**
   - Preserved all other aspects of the spoiler handling logic
   - Ensured spoiler warnings and content delivery work as expected
   - Kept the same mobile device handling and accessibility features

## Technical Implementation

The solution is simple but effective. In the `showSpoilerContent()` method, we now check if the message already exists before adding it:

```javascript
const messageExists = this.chatMessages.some(
  msg => msg.role === 'assistant' && msg.content === this.pendingSpoilerResponse
);

if (!messageExists) {
  this.chatMessages.push({
    role: 'assistant',
    content: this.pendingSpoilerResponse
  });
}
```

This approach prevents duplicate messages while maintaining all other functionality of the spoiler warning system.

## Testing

Verified functionality in the following scenarios:
- Asking questions that trigger spoiler warnings 
- Testing with both conversation history present and absent
- Checking that responses appear exactly once in all cases
- Ensuring all other aspects of the chatbot functionality remain intact

The fix has been thoroughly tested across mobile and desktop environments to ensure consistent behavior regardless of device type.

Closes #34